### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/builder/hyperone/config.go
+++ b/builder/hyperone/config.go
@@ -52,7 +52,7 @@ type Config struct {
 	ImageTags map[string]string `mapstructure:"image_tags" required:"false"`
 	// Same as [`image_tags`](#image_tags) but defined as a singular repeatable
 	// block containing a `key` and a `value` field. In HCL2 mode the
-	// [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+	// [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
 	// will allow you to create those programatically.
 	ImageTag config.KeyValues `mapstructure:"image_tag" required:"false"`
 	// The service of the resulting image.
@@ -65,7 +65,7 @@ type Config struct {
 	VmTags map[string]string `mapstructure:"vm_tags" required:"false"`
 	// Same as [`vm_tags`](#vm_tags) but defined as a singular repeatable block
 	// containing a `key` and a `value` field. In HCL2 mode the
-	// [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+	// [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
 	// will allow you to create those programatically.
 	VmTag config.NameValues `mapstructure:"vm_tag" required:"false"`
 	// The name of the created disk.

--- a/docs-partials/builder/hyperone/Config-not-required.mdx
+++ b/docs-partials/builder/hyperone/Config-not-required.mdx
@@ -16,7 +16,7 @@
 
 - `image_tag` ([]{key string, value string}) - Same as [`image_tags`](#image_tags) but defined as a singular repeatable
   block containing a `key` and a `value` field. In HCL2 mode the
-  [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+  [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
   will allow you to create those programatically.
 
 - `image_service` (string) - The service of the resulting image.
@@ -27,7 +27,7 @@
 
 - `vm_tag` ([]{name string, value string}) - Same as [`vm_tags`](#vm_tags) but defined as a singular repeatable block
   containing a `key` and a `value` field. In HCL2 mode the
-  [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+  [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
   will allow you to create those programatically.
 
 - `disk_name` (string) - The name of the created disk.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ The HyperOne Packer Plugin with a single builder able to create new images on th
 The builder takes a source image, runs any provisioning necessary on
 the image after launching it, then creates a reusable image.
 
-- [hyperone](/docs/builders/hyperone.mdx)
+- [hyperone](/packer/plugins/builders/hyperone.mdx)
 
 ## Installation
 

--- a/docs/builders/hyperone.mdx
+++ b/docs/builders/hyperone.mdx
@@ -87,7 +87,7 @@ segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder.
 
 ### Required:
@@ -123,7 +123,7 @@ builder.
 
 - `image_name` (string) - The name of the resulting image. Defaults to
   `packer-{{timestamp}}`
-  (see [configuration templates](/docs/templates/legacy_json_templates/engine) for more info).
+  (see [configuration templates](/packer/docs/templates/legacy_json_templates/engine) for more info).
 
 - `image_service` (string) - The service of the resulting image.
 


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them